### PR TITLE
Use nickjj.docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Role Variables
 Dependencies
 ------------
 
-- [geerlingguy.docker](https://github.com/geerlingguy/ansible-role-docker)
+- [nickjj.docker](https://github.com/nickjj/ansible-docker)
 
 Example Playbook
 ----------------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -61,6 +61,6 @@ galaxy_info:
   #       Maximum 20 tags per role.
 
 dependencies:
-  - geerlingguy.docker
+  - nickjj.docker
 # List your role dependencies here, one per line. Be sure to remove the '[]' above,
 # if you add dependencies to this list.

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,4 +1,4 @@
 ---
 
-- name: geerlingguy.docker
-  version: 2.5.2
+- name: nickjj.docker
+  version: v1.9.0

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -5,6 +5,7 @@ import testinfra.utils.ansible_runner
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
+
 def test_docker_gc(host):
     crontask = host.file('/etc/cron.d/docker-gc')
 


### PR DESCRIPTION
Avoids conflict with other code that uses nickjj.docker instead (e.g. jenkins-slaves)